### PR TITLE
Define all input validation consistently in the schema

### DIFF
--- a/graphql/sanctum.graphql
+++ b/graphql/sanctum.graphql
@@ -9,8 +9,8 @@ type AccessToken {
 }
 
 input LoginInput {
-    email: String!
-    password: String!
+    email: String! @rules(apply: ["required", "email"])
+    password: String! @rules(apply: ["required", "string"])
 }
 
 type LogoutResponse {
@@ -28,16 +28,16 @@ type EmailVerificationResponse {
 }
 
 input VerifyEmailInput {
-    id: String!
-    hash: String!
+    id: ID! @rules(apply: ["required", "exists:users,id"])
+    hash: String! @rules(apply: ["required", "string"])
 }
 
 input RegisterInput {
     name: String! @rules(apply: ["required", "string"])
     email: String! @rules(apply: ["required", "email", "unique:users,email"])
     password: String! @rules(apply: ["required", "confirmed"])
-    password_confirmation: String!
-    verification_url: String
+    password_confirmation: String! @rules(apply: ["required", "string"])
+    verification_url: String @rules(apply: ["url"])
 }
 
 extend type Mutation {

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -4,21 +4,15 @@ namespace DanielDeWit\LighthouseSanctum\GraphQL\Mutations;
 
 use Exception;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
-use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Nuwave\Lighthouse\Exceptions\AuthenticationException;
 use RuntimeException;
 
 class Login
 {
-    protected ValidationFactory $validator;
     protected AuthManager $authManager;
 
-    public function __construct(
-        ValidationFactory $validator,
-        AuthManager $authManager
-    )
+    public function __construct(AuthManager $authManager)
     {
-        $this->validator = $validator;
         $this->authManager = $authManager;
     }
 
@@ -26,28 +20,20 @@ class Login
      * @param null $_
      * @param string[] $args
      * @return string[]
-     * @throws ValidationException
-     * @throws \Illuminate\Validation\ValidationException
      * @throws Exception
      */
     public function __invoke($_, array $args): array
     {
-        $validator = $this->validator
-            ->make($args, [
-                'email'    => 'required|email',
-                'password' => 'required',
-            ]);
-
         $userProvider = $this->authManager->createUserProvider(config('lighthouse-sanctum.provider'));
 
         if (! $userProvider) {
             throw new RuntimeException('No UserProvider available.');
         }
 
-        $user = $userProvider->retrieveByCredentials($validator->validated());
+        $user = $userProvider->retrieveByCredentials($args);
 
         if (! $user) {
-            throw new ValidationException('The provided credentials are incorrect.', $validator);
+            throw new AuthenticationException('The provided credentials are incorrect.');
         }
 
         if (! method_exists($user, 'createToken')) {


### PR DESCRIPTION
The following situations occurred regarding input validation:

* Some input only depended on schema restrictions (e.g. `field: String!`).
* Some input used the `@rules` directive in the schema.
* Some input used a validator in the mutation.

This PR remedies that by:
* Only using the `@rules` directive in the schema thereby centralizing all validation definitions.
* Validating all input fields regardless of schema restrictions, so any mutation can always assume that the expected input is present and valid.