### PR TITLE
Add backtics to GraphQL input descriptions

### DIFF
--- a/graphql/sanctum.graphql
+++ b/graphql/sanctum.graphql
@@ -44,7 +44,7 @@ input RegisterInput {
 The url used to verify the email address.
 Use __ID__ and __HASH__ to inject values.
 
-e.g; https://my-front-end.com/verify-email?id=__ID__&hash=__HASH__
+e.g; `https://my-front-end.com/verify-email?id=__ID__&hash=__HASH__`
 """
 input VerificationUrlInput {
     url: String! @rules(apply: ["required", "url"])
@@ -59,7 +59,7 @@ input ForgotPasswordInput {
 The url used to reset the password.
 Use the `__EMAIL__` and `__TOKEN__` placeholders to inject the reset password email and token.
 
-e.g; https://my-front-end.com?reset-password?email=__EMAIL__&token=__TOKEN__
+e.g; `https://my-front-end.com?reset-password?email=__EMAIL__&token=__TOKEN__`
 """
 input ResetPasswordUrlInput {
     url: String! @rules(apply: ["required", "url"])


### PR DESCRIPTION
Without backtics the example urls are being parsed by graphql-playground removing the underscores