### PR TITLE
Fix ResetPasswordTest

### DIFF
--- a/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
@@ -7,7 +7,6 @@ namespace DanielDeWit\LighthouseSanctum\Tests\Integration\GraphQL\Mutations;
 use DanielDeWit\LighthouseSanctum\Tests\Integration\AbstractIntegrationTest;
 use DanielDeWit\LighthouseSanctum\Tests\stubs\Users\UserHasApiTokens;
 use Illuminate\Auth\Notifications\ResetPassword;
-use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Sanctum\Sanctum;
 
@@ -24,8 +23,6 @@ class ForgotPasswordTest extends AbstractIntegrationTest
         $user = UserHasApiTokens::factory()->create([
             'email' => 'john.doe@gmail.com',
         ]);
-
-        $user->notify(new ResetPasswordNotification('bla'));
 
         Sanctum::actingAs($user);
 


### PR DESCRIPTION
By manually notifying the user before the GraphQL mutation, we are not testing it properly.