### PR TITLE
Improve extendability of the register mutation

### DIFF
--- a/src/GraphQL/Mutations/Register.php
+++ b/src/GraphQL/Mutations/Register.php
@@ -13,6 +13,7 @@ use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Laravel\Sanctum\Contracts\HasApiTokens;
 
@@ -48,9 +49,10 @@ class Register
         /** @var EloquentUserProvider $userProvider */
         $userProvider = $this->createUserProvider();
 
-        $user = $userProvider->createModel();
-        $user->fill($this->getPropertiesFromArgs($args));
-        $user->save();
+        $user = $this->saveUser(
+            $userProvider->createModel(),
+            $this->getPropertiesFromArgs($args),
+        );
 
         if ($user instanceof MustVerifyEmail) {
             if (isset($args['verification_url'])) {
@@ -73,6 +75,20 @@ class Register
             'token'  => $user->createToken('default')->plainTextToken,
             'status' => 'SUCCESS',
         ];
+    }
+
+    /**
+     * @param Model $user
+     * @param array<string, mixed> $attributes
+     * @return Model
+     */
+    protected function saveUser(Model $user, array $attributes): Model
+    {
+        $user
+            ->fill($attributes)
+            ->save();
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Improve extendability of the register mutation by filling and saving user in separate method, which can be easily overridden.

### Example

```graphql
// sanctum.graphql
input RegisterInput {
    first_name: String!
    last_name: String!
    company_id: ID! @rules(apply: ["bail", "uuid", "exists:companies,id"])
    email: String! @rules(apply: ["bail", "email", "unique:users,email"])
    password: String! @rules(apply: ["confirmed"])
    password_confirmation: String!
    verification_url: VerificationUrlInput
}
```

```php
use DanielDeWit\LighthouseSanctum\GraphQL\Mutations\Register as BaseRegister;

class Register extends BaseRegister
{
    /**
     * @param Model $user
     * @param array<string, mixed> $attributes
     * @return Model
     */
    protected function saveUser(Model $user, array $attributes): Model
    {
        $userAttributes = Arr::except($attributes, [
            'company_id',
        ]);
		
        $company = Company::findOrFail($attributes['company_id']);
        
        $user->fill($userAttributes);
        $user->company()->associate($company);
        $user->save();

        return $user;
    }
}
```