### PR TITLE
Fix tests that fail because validation error message changes in laravel/laravel 8.5.21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "mockery/mockery": "^1.3.3",
         "nunomaduro/larastan": "^0.7.2",
         "orchestra/testbench": "^6.5",
+        "orchestra/testbench-core": "^v6.23.1",
         "phpstan/phpstan-mockery": "^0.12.13",
         "phpstan/phpstan-phpunit": "^0.12.18",
         "phpunit/phpunit": "^9.5",

--- a/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
@@ -205,7 +205,7 @@ class ForgotPasswordTest extends AbstractIntegrationTest
             ->assertGraphQLErrorMessage('Validation failed for the field [forgotPassword].')
             ->assertGraphQLValidationError(
                 'input.reset_password_url.url',
-                'The input.reset password url.url format is invalid.',
+                'The input.reset password url.url must be a valid URL.',
             );
     }
 }

--- a/tests/Integration/GraphQL/Mutations/RegisterTest.php
+++ b/tests/Integration/GraphQL/Mutations/RegisterTest.php
@@ -467,7 +467,7 @@ class RegisterTest extends AbstractIntegrationTest
             ->assertGraphQLErrorMessage('Validation failed for the field [register].')
             ->assertGraphQLValidationError(
                 'input.verification_url.url',
-                'The input.verification url.url format is invalid.',
+                'The input.verification url.url must be a valid URL.',
             );
     }
 }

--- a/tests/Integration/GraphQL/Mutations/ResendEmailVerificationTest.php
+++ b/tests/Integration/GraphQL/Mutations/ResendEmailVerificationTest.php
@@ -318,7 +318,7 @@ class ResendEmailVerificationTest extends AbstractIntegrationTest
             ->assertGraphQLErrorMessage('Validation failed for the field [resendEmailVerification].')
             ->assertGraphQLValidationError(
                 'input.verification_url.url',
-                'The input.verification url.url format is invalid.',
+                'The input.verification url.url must be a valid URL.',
             );
     }
 }


### PR DESCRIPTION
When checking out this package and running the tests, some assertions on URL validity error messages fail, if the installed version of `orchestra/testbench-core` is equal or higher than `^v6.23.1`, because of this change: 
https://github.com/orchestral/testbench-core/commit/f189915445275e511ae12cef356246bee8faca6f

Or the `laravel/laravel` equivalent:
https://github.com/laravel/laravel/commit/866589128430c55385cb13ddae0061c628245be2

To fix this, I have added a more explicit requirement for `orchestra/testbench-core` in the `composer.json` file. This is, unfortunately, a breaking change.