### PR TITLE
Extracted the transformation of URL's for email verification and password resets to a separate method

### DIFF
--- a/src/Contracts/Services/EmailVerificationServiceInterface.php
+++ b/src/Contracts/Services/EmailVerificationServiceInterface.php
@@ -9,6 +9,8 @@ use Nuwave\Lighthouse\Exceptions\AuthenticationException;
 
 interface EmailVerificationServiceInterface
 {
+    public function transformUrl(MustVerifyEmail $user, string $url): string;
+
     public function setVerificationUrl(string $url): void;
 
     /**

--- a/src/Contracts/Services/ResetPasswordServiceInterface.php
+++ b/src/Contracts/Services/ResetPasswordServiceInterface.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace DanielDeWit\LighthouseSanctum\Contracts\Services;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Database\Eloquent\Model;
 
 interface ResetPasswordServiceInterface
 {
+    public function transformUrl(CanResetPassword $notifiable, string $token, string $url): string;
+
     public function setResetPasswordUrl(string $url): void;
 
     /**

--- a/src/Services/EmailVerificationService.php
+++ b/src/Services/EmailVerificationService.php
@@ -26,17 +26,22 @@ class EmailVerificationService implements EmailVerificationServiceInterface
         $this->expiresIn        = $expiresIn;
     }
 
+    public function transformUrl(MustVerifyEmail $user, string $url): string
+    {
+        $parameters = $this->createUrlParameters($user);
+
+        return str_replace([
+            '__ID__',
+            '__HASH__',
+            '__EXPIRES__',
+            '__SIGNATURE__',
+        ], $parameters, $url);
+    }
+
     public function setVerificationUrl(string $url): void
     {
-        VerifyEmail::createUrlUsing(function ($user) use ($url) {
-            $parameters = $this->createUrlParameters($user);
-
-            return str_replace([
-                '__ID__',
-                '__HASH__',
-                '__EXPIRES__',
-                '__SIGNATURE__',
-            ], $parameters, $url);
+        VerifyEmail::createUrlUsing(function (MustVerifyEmail $user) use ($url) {
+            return $this->transformUrl($user, $url);
         });
     }
 

--- a/src/Services/ResetPasswordService.php
+++ b/src/Services/ResetPasswordService.php
@@ -24,16 +24,21 @@ class ResetPasswordService implements ResetPasswordServiceInterface
         $this->dispatcher = $dispatcher;
     }
 
+    public function transformUrl(CanResetPassword $notifiable, string $token, string $url): string
+    {
+        return str_replace([
+            '__EMAIL__',
+            '__TOKEN__',
+        ], [
+            $notifiable->getEmailForPasswordReset(),
+            $token,
+        ], $url);
+    }
+
     public function setResetPasswordUrl(string $url): void
     {
         ResetPasswordNotification::createUrlUsing(function (CanResetPassword $notifiable, string $token) use ($url) {
-            return str_replace([
-                '__EMAIL__',
-                '__TOKEN__',
-            ], [
-                $notifiable->getEmailForPasswordReset(),
-                $token,
-            ], $url);
+            return $this->transformUrl($notifiable, $token, $url);
         });
     }
 

--- a/tests/Integration/Services/ResetPasswordServiceTest.php
+++ b/tests/Integration/Services/ResetPasswordServiceTest.php
@@ -33,6 +33,23 @@ class ResetPasswordServiceTest extends AbstractIntegrationTest
     /**
      * @test
      */
+    public function it_transforms_a_reset_password_url(): void
+    {
+        /** @var UserMustVerifyEmail $user */
+        $user = UserMustVerifyEmail::factory()->create([
+            'email' => 'user@example.com',
+        ]);
+
+        $token = 'token123';
+
+        $url = $this->service->transformUrl($user, $token, 'https://mysite.com/reset-password/__EMAIL__/__TOKEN__');
+
+        static::assertSame('https://mysite.com/reset-password/user@example.com/token123', $url);
+    }
+
+    /**
+     * @test
+     */
     public function it_sets_the_reset_password_url(): void
     {
         /** @var UserMustVerifyEmail $user */


### PR DESCRIPTION
**Changes**
* Added `MustVerifyEmail` contract to `VerifyEmail::createUrlUsing` callback in the `EmailVerificationService`
* Extracted the transformation of URL's to a separate method