### PR TITLE
Ability to customize credential keys e.g: email/username

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Add [Laravel Sanctum](https://github.com/laravel/sanctum) support to [Lighthouse
     - [Email Verification](#email-verification)
     - [Forgot Password](#forgot-password)
     - [Reset Password](#reset-password)
+- [Custom Identification](#custom-identification)
 
 ## Requirements
 
@@ -133,6 +134,8 @@ Apply the Authorization header on subsequent calls using the token
 ```json
   "Authorization": "Bearer 1|lJo1cMhrW9tIUuGwlV1EPjKnvfZKzvgpGgplbwX9"
 ```
+
+(Using something other than email? See [Custom Identification](#custom-identification))
 
 ### Logout
 
@@ -294,6 +297,33 @@ mutation {
     }
 }
 ```
+
+### Custom Identification
+
+You can customize which fields are used for authenticating users.
+
+For example, using `username` instead of the default `email`.
+```php
+/*
+|--------------------------------------------------------------------------
+| Identification
+|--------------------------------------------------------------------------
+|
+| Configure the credential fields by which the user will be identified.
+| Default: email
+*/
+
+'user_identifier_field_name' => 'username',
+```
+
+Update the GraphQL schema accordingly
+
+```graphql
+input LoginInput {
+    username: String! @rules(apply: ["required"])
+}
+```
+
 
 ## Testing
 

--- a/config/lighthouse-sanctum.php
+++ b/config/lighthouse-sanctum.php
@@ -26,4 +26,15 @@ return [
     |
     */
     'use_signed_email_verification_url' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identification
+    |--------------------------------------------------------------------------
+    |
+    | Configure the credential fields by which the user will be identified.
+    | Default: email
+    */
+
+    'user_identifier_field_name' => 'email',
 ];

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -36,8 +36,11 @@ class Login
     {
         $userProvider = $this->createUserProvider();
 
+        $identificationKey = $this->getConfig()
+            ->get('lighthouse-sanctum.identification.user_identifier_field_name', 'email');
+
         $user = $userProvider->retrieveByCredentials([
-            'email'    => $args['email'],
+            $identificationKey => $args[$identificationKey],
             'password' => $args['password'],
         ]);
 

--- a/src/Services/ResetPasswordService.php
+++ b/src/Services/ResetPasswordService.php
@@ -37,7 +37,8 @@ class ResetPasswordService implements ResetPasswordServiceInterface
 
     public function setResetPasswordUrl(string $url): void
     {
-        ResetPasswordNotification::createUrlUsing(function (CanResetPassword $notifiable, string $token) use ($url) {
+        /** @phpstan-ignore-next-line */
+        ResetPasswordNotification::createUrlUsing(function (CanResetPassword $notifiable, string $token) use ($url): string {
             return $this->transformUrl($notifiable, $token, $url);
         });
     }

--- a/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
@@ -45,6 +45,7 @@ class ForgotPasswordTest extends AbstractIntegrationTest
         ]);
 
         Notification::assertSentTo($user, function (ResetPassword $notification) use ($user) {
+            /** @phpstan-ignore-next-line */
             $url = call_user_func($notification::$createUrlCallback, $user, $notification->token);
 
             return $url === "https://my-front-end.com/reset-password?email=john.doe@gmail.com&token={$notification->token}";

--- a/tests/Integration/Services/ResetPasswordServiceTest.php
+++ b/tests/Integration/Services/ResetPasswordServiceTest.php
@@ -61,6 +61,7 @@ class ResetPasswordServiceTest extends AbstractIntegrationTest
 
         $this->service->setResetPasswordUrl('https://mysite.com/reset-password/__EMAIL__/__TOKEN__');
 
+        /** @phpstan-ignore-next-line */
         $url = call_user_func(ResetPassword::$createUrlCallback, $user, $token);
 
         static::assertSame('https://mysite.com/reset-password/user@example.com/token123', $url);

--- a/tests/Traits/MocksUserProvider.php
+++ b/tests/Traits/MocksUserProvider.php
@@ -38,7 +38,12 @@ trait MocksUserProvider
             ->shouldReceive('get')
             ->with('lighthouse-sanctum.provider')
             ->andReturn('sanctum-provider')
-            ->getMock();
+            ->getMock()
+            ->shouldReceive('get')
+            ->with('lighthouse-sanctum.identification.user_identifier_field_name', 'email')
+            ->andReturn('email')
+            ->getMock()
+        ;
 
         return $config;
     }

--- a/tests/stubs/Users/UserHasApiTokens.php
+++ b/tests/stubs/Users/UserHasApiTokens.php
@@ -17,10 +17,13 @@ class UserHasApiTokens extends User implements HasApiTokensContract
     use HasFactory;
     use Notifiable;
 
+    /**
+     * @var string
+     */
     protected $table = 'users';
 
     /**
-     * @var string[]
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',
@@ -30,7 +33,7 @@ class UserHasApiTokens extends User implements HasApiTokensContract
     ];
 
     /**
-     * @var string[]
+     * @var array<int, string>
      */
     protected $hidden = [
         'password',


### PR DESCRIPTION
Closes #76 

A new section is added to config/lighthouse-sanctum.php which allows for custom user identification field to be used when authenticating.

For example, using `username` instead of the default `email`.
```php
/*
|--------------------------------------------------------------------------
| Identification
|--------------------------------------------------------------------------
|
| Configure the credential fields by which the user will be identified.
| Default: email
*/

'user_identifier_field_name' => 'username',
```

Update the GraphQL schema accordingly

```graphql
input LoginInput {
    username: String! @rules(apply: ["required"])
}
```