### PR TITLE
Fix phpstan issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,16 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
-/.editorconfig      export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.travis.yml            export-ignore
+/phpunit.xml.dist       export-ignore
+/.scrutinizer.yml       export-ignore
+/tests                  export-ignore
+/.editorconfig          export-ignore
+/stubs                  export-ignore
+/phpstan.neon           export-ignore
+/.php_cs_tests.php      export-ignore
+/.php_cs.common.php     export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.coveralls.yml         export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,7 @@
 /.editorconfig          export-ignore
 /stubs                  export-ignore
 /phpstan.neon           export-ignore
-/.php_cs_tests.php      export-ignore
+/.php_cs.tests.php      export-ignore
 /.php_cs.common.php     export-ignore
 /.php-cs-fixer.dist.php export-ignore
 /.coveralls.yml         export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .phpunit.cache
 .php_cs.cache
 .php_cs.tests.cache
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add [Laravel Sanctum](https://github.com/laravel/sanctum) support to [Lighthouse
 
 - [laravel/laravel:^9.0](https://github.com/laravel/laravel)
 - [laravel/sanctum:^2.0](https://github.com/laravel/sanctum)
-- [nuwave/lighthouse:^5.5](https://github.com/nuwave/lighthouse)
+- [nuwave/lighthouse:^5.55.1](https://github.com/nuwave/lighthouse)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.0.2",
         "laravel/framework": "^9.0",
         "laravel/sanctum": "^2.14",
-        "nuwave/lighthouse": "^5.5"
+        "nuwave/lighthouse": "^5.55.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -66,6 +66,9 @@
             "php-cs-fixer fix",
             "php-cs-fixer fix --config=.php_cs.tests.php"
         ],
-        "test": "vendor/bin/phpunit --no-coverage"
+        "test": "vendor/bin/phpunit --no-coverage",
+        "post-autoload-dump": [
+            "@php ./vendor/bin/testbench package:discover --ansi"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         }
     },
     "scripts": {
+        "post-autoload-dump": [
+            "@php ./vendor/bin/testbench package:discover --ansi"
+        ],
         "analyze": "vendor/phpstan/phpstan/phpstan analyse",
         "check-style": [
             "php-cs-fixer fix --diff --dry-run",
@@ -66,9 +69,6 @@
             "php-cs-fixer fix",
             "php-cs-fixer fix --config=.php_cs.tests.php"
         ],
-        "test": "vendor/bin/phpunit --no-coverage",
-        "post-autoload-dump": [
-            "@php ./vendor/bin/testbench package:discover --ansi"
-        ]
+        "test": "vendor/bin/phpunit --no-coverage"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,9 +5,12 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  level: 8
+  level: max
   paths:
     - src
     - tests
-  ignoreErrors:
-    - '#Call to an undefined method Illuminate\\Testing\\TestResponse::assertGraphQLErrorMessage\(\).#'
+  stubFiles:
+    - vendor/nuwave/lighthouse/_ide_helper.php
+    - stubs/Illuminate/Auth/Notifications/ResetPassword.stub
+    - stubs/Illuminate/Auth/Notifications/Notification.stub
+    - stubs/Illuminate/Contracts/Auth/CanResetPassword.stub

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,4 @@ parameters:
     - src
     - tests
   ignoreErrors:
-    -
-      message: '#Parameter \#1 \$(function|callback) of function call_user_func expects callable\(\): mixed, Closure\|null given\.#'
-      path: tests
     - '#Call to an undefined method Illuminate\\Testing\\TestResponse::assertGraphQLErrorMessage\(\).#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  level: max
+  level: 8
   paths:
     - src
     - tests

--- a/src/Services/ResetPasswordService.php
+++ b/src/Services/ResetPasswordService.php
@@ -37,7 +37,6 @@ class ResetPasswordService implements ResetPasswordServiceInterface
 
     public function setResetPasswordUrl(string $url): void
     {
-        /** @phpstan-ignore-next-line */
         ResetPasswordNotification::createUrlUsing(function (CanResetPassword $notifiable, string $token) use ($url): string {
             return $this->transformUrl($notifiable, $token, $url);
         });

--- a/stubs/Illuminate/Auth/Notifications/Notification.stub
+++ b/stubs/Illuminate/Auth/Notifications/Notification.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+class Notification
+{
+}

--- a/stubs/Illuminate/Auth/Notifications/ResetPassword.stub
+++ b/stubs/Illuminate/Auth/Notifications/ResetPassword.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Auth\Notifications;
+
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Notifications\Notification;
+
+class ResetPassword extends Notification
+{
+    /**
+     * Set a callback that should be used when creating the reset password button URL.
+     *
+     * @param  \Closure(CanResetPassword, string): string  $callback
+     * @return void
+     */
+    public static function createUrlUsing($callback)
+    {
+    }
+}

--- a/stubs/Illuminate/Contracts/Auth/CanResetPassword.stub
+++ b/stubs/Illuminate/Contracts/Auth/CanResetPassword.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface CanResetPassword
+{
+}

--- a/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
@@ -45,7 +45,7 @@ class ForgotPasswordTest extends AbstractIntegrationTest
         ]);
 
         Notification::assertSentTo($user, function (ResetPassword $notification) use ($user) {
-            /** @phpstan-ignore-next-line */
+            static::assertIsCallable($notification::$createUrlCallback);
             $url = call_user_func($notification::$createUrlCallback, $user, $notification->token);
 
             return $url === "https://my-front-end.com/reset-password?email=john.doe@gmail.com&token={$notification->token}";

--- a/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPasswordTest.php
@@ -46,6 +46,7 @@ class ForgotPasswordTest extends AbstractIntegrationTest
 
         Notification::assertSentTo($user, function (ResetPassword $notification) use ($user) {
             static::assertIsCallable($notification::$createUrlCallback);
+
             $url = call_user_func($notification::$createUrlCallback, $user, $notification->token);
 
             return $url === "https://my-front-end.com/reset-password?email=john.doe@gmail.com&token={$notification->token}";

--- a/tests/Integration/GraphQL/Mutations/RegisterTest.php
+++ b/tests/Integration/GraphQL/Mutations/RegisterTest.php
@@ -93,6 +93,8 @@ class RegisterTest extends AbstractIntegrationTest
         $user = UserMustVerifyEmail::first();
 
         Notification::assertSentTo($user, function (VerifyEmail $notification) use ($user) {
+            static::assertIsCallable($notification::$createUrlCallback);
+
             $url = call_user_func($notification::$createUrlCallback, $user);
 
             /** @var int|string $id */
@@ -151,6 +153,8 @@ class RegisterTest extends AbstractIntegrationTest
         $user = UserMustVerifyEmail::first();
 
         Notification::assertSentTo($user, function (VerifyEmail $notification) use ($user) {
+            static::assertIsCallable($notification::$createUrlCallback);
+
             $url = call_user_func($notification::$createUrlCallback, $user);
 
             /** @var int|string $id */

--- a/tests/Integration/GraphQL/Mutations/ResendEmailVerificationTest.php
+++ b/tests/Integration/GraphQL/Mutations/ResendEmailVerificationTest.php
@@ -50,6 +50,8 @@ class ResendEmailVerificationTest extends AbstractIntegrationTest
         static::assertSame('EMAIL_SENT', $response->json('data.resendEmailVerification.status'));
 
         Notification::assertSentTo($user, function (VerifyEmail $notification) use ($user) {
+            static::assertIsCallable($notification::$createUrlCallback);
+
             $url = call_user_func($notification::$createUrlCallback, $user);
 
             $hash = sha1('foo@bar.com');
@@ -98,6 +100,8 @@ class ResendEmailVerificationTest extends AbstractIntegrationTest
         static::assertSame('EMAIL_SENT', $response->json('data.resendEmailVerification.status'));
 
         Notification::assertSentTo($user, function (VerifyEmail $notification) use ($user) {
+            static::assertIsCallable($notification::$createUrlCallback);
+
             $url = call_user_func($notification::$createUrlCallback, $user);
 
             $hash      = sha1('foo@bar.com');

--- a/tests/Integration/Services/EmailVerificationServiceTest.php
+++ b/tests/Integration/Services/EmailVerificationServiceTest.php
@@ -82,6 +82,8 @@ class EmailVerificationServiceTest extends AbstractIntegrationTest
 
         $this->service->setVerificationUrl('https://mysite.com/verify-email/__ID__/__HASH__');
 
+        static::assertIsCallable(VerifyEmail::$createUrlCallback);
+
         $url = call_user_func(VerifyEmail::$createUrlCallback, $user);
 
         static::assertSame('https://mysite.com/verify-email/12345/' . sha1('user@example.com'), $url);
@@ -101,6 +103,8 @@ class EmailVerificationServiceTest extends AbstractIntegrationTest
         ]);
 
         $this->service->setVerificationUrl('https://mysite.com/verify-email/__ID__/__HASH__/__EXPIRES__/__SIGNATURE__');
+
+        static::assertIsCallable(VerifyEmail::$createUrlCallback);
 
         $url = call_user_func(VerifyEmail::$createUrlCallback, $user);
 

--- a/tests/Integration/Services/ResetPasswordServiceTest.php
+++ b/tests/Integration/Services/ResetPasswordServiceTest.php
@@ -61,7 +61,8 @@ class ResetPasswordServiceTest extends AbstractIntegrationTest
 
         $this->service->setResetPasswordUrl('https://mysite.com/reset-password/__EMAIL__/__TOKEN__');
 
-        /** @phpstan-ignore-next-line */
+        static::assertIsCallable(ResetPassword::$createUrlCallback);
+
         $url = call_user_func(ResetPassword::$createUrlCallback, $user, $token);
 
         static::assertSame('https://mysite.com/reset-password/user@example.com/token123', $url);


### PR DESCRIPTION
By checking for callable removed the need to ignore phpstan.

Lowering phpstan to level 8 reduces the need for the custom phpstan ignore rule:
```
'#Parameter \#1 \$(function|callback) of function call_user_func expects callable\(\): mixed, Closure\|null given\.#'
```

[Level 9](https://phpstan.org/user-guide/rule-levels) is unnecessarily strict, it will never allow anything other than `mixed` to be passed.

> 9. be strict about the mixed type - the only allowed operation you can do with it is to pass it to another mixed
