### PR TITLE
Wrong config value usage; fixes #80

### DIFF
--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -37,7 +37,7 @@ class Login
         $userProvider = $this->createUserProvider();
 
         $identificationKey = $this->getConfig()
-            ->get('lighthouse-sanctum.identification.user_identifier_field_name', 'email');
+            ->get('lighthouse-sanctum.user_identifier_field_name', 'email');
 
         $user = $userProvider->retrieveByCredentials([
             $identificationKey => $args[$identificationKey],

--- a/tests/Traits/MocksUserProvider.php
+++ b/tests/Traits/MocksUserProvider.php
@@ -40,7 +40,7 @@ trait MocksUserProvider
             ->andReturn('sanctum-provider')
             ->getMock()
             ->shouldReceive('get')
-            ->with('lighthouse-sanctum.identification.user_identifier_field_name', 'email')
+            ->with('lighthouse-sanctum.user_identifier_field_name', 'email')
             ->andReturn('email')
             ->getMock()
         ;

--- a/tests/Unit/GraphQL/Mutations/LoginTest.php
+++ b/tests/Unit/GraphQL/Mutations/LoginTest.php
@@ -75,7 +75,7 @@ class LoginTest extends AbstractUnitTest
             ->andReturn('sanctum-provider')
             ->getMock()
             ->shouldReceive('get')
-            ->with('lighthouse-sanctum.identification.user_identifier_field_name', 'email')
+            ->with('lighthouse-sanctum.user_identifier_field_name', 'email')
             ->andReturn('custom_key')
             ->getMock();
 


### PR DESCRIPTION
Changes the files edited in PR #77 that make use of `lighthouse-sanctum.identification.user_identifier_field_name` to use `lighthouse-sanctum.user_identifier_field_name` instead (as per readme + config file)

Fixes #80 