### PR TITLE
Fix risky tests

### DIFF
--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -22,6 +22,11 @@ abstract class AbstractIntegrationTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
      * @param Application $app
      * @return string[]
      */

--- a/tests/Unit/Services/EmailVerificationServiceTest.php
+++ b/tests/Unit/Services/EmailVerificationServiceTest.php
@@ -131,6 +131,7 @@ class EmailVerificationServiceTest extends AbstractUnitTest
         /** @var MustVerifyEmail|MockInterface $user */
         $user = Mockery::mock(MustVerifyEmail::class)
             ->shouldReceive('getEmailForVerification')
+            ->once()
             ->andReturn($email)
             ->getMock();
 

--- a/tests/Unit/Services/ResetPasswordServiceTest.php
+++ b/tests/Unit/Services/ResetPasswordServiceTest.php
@@ -23,14 +23,17 @@ class ResetPasswordServiceTest extends AbstractUnitTest
         /** @var User|MockInterface $user */
         $user = Mockery::mock(User::class)
             ->shouldReceive('setAttribute')
+            ->once()
             ->with('password', 'some-hash')
             ->getMock()
             ->shouldReceive('save')
+            ->once()
             ->getMock();
 
         /** @var Hasher|MockInterface $hasher */
         $hasher = Mockery::mock(Hasher::class)
             ->shouldReceive('make')
+            ->once()
             ->with('some-password')
             ->andReturn('some-hash')
             ->getMock();
@@ -38,6 +41,7 @@ class ResetPasswordServiceTest extends AbstractUnitTest
         /** @var Dispatcher|MockInterface $dispatcher */
         $dispatcher = Mockery::mock(Dispatcher::class)
             ->shouldReceive('dispatch')
+            ->once()
             ->withArgs(function (PasswordReset $event) use ($user) {
                 return $event->user === $user;
             })


### PR DESCRIPTION
Mockery 1.5.1 requires count of shouldReceive calls.

https://github.com/mockery/mockery/issues/1190